### PR TITLE
修正: スコアが大きくなりすぎるバグを修正しました

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: -1912819020743921416}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Player
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -151,6 +151,7 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   gameOverText: {fileID: 0}
+  scoreText: {fileID: 0}
 --- !u!1 &6202300359712352728
 GameObject:
   m_ObjectHideFlags: 0
@@ -247,7 +248,7 @@ GameObject:
   - component: {fileID: 3375180993029041656}
   m_Layer: 0
   m_Name: GrazeCollision
-  m_TagString: Player
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/Easy.unity
+++ b/Assets/Scenes/Easy.unity
@@ -285,8 +285,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -210, y: 400}
-  m_SizeDelta: {x: 330, y: 90}
+  m_AnchoredPosition: {x: -190, y: 400}
+  m_SizeDelta: {x: 350, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &197099949
 MonoBehaviour:
@@ -2226,6 +2226,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 6202300359686033088, guid: 8df65eb10e3ea43ad814a77fa881a5a6, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
     - target: {fileID: 6202300359686033092, guid: 8df65eb10e3ea43ad814a77fa881a5a6, type: 3}
       propertyPath: m_Radius
       value: 1.3
@@ -2281,6 +2285,10 @@ PrefabInstance:
     - target: {fileID: 7575486271925416748, guid: 8df65eb10e3ea43ad814a77fa881a5a6, type: 3}
       propertyPath: m_LocalScale.x
       value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8258515497025956310, guid: 8df65eb10e3ea43ad814a77fa881a5a6, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
       objectReference: {fileID: 0}
     - target: {fileID: 8725605871751579129, guid: 8df65eb10e3ea43ad814a77fa881a5a6, type: 3}
       propertyPath: m_Radius

--- a/Assets/Scenes/Hard.unity
+++ b/Assets/Scenes/Hard.unity
@@ -2550,8 +2550,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -210, y: 400}
-  m_SizeDelta: {x: 330, y: 90}
+  m_AnchoredPosition: {x: -190, y: 400}
+  m_SizeDelta: {x: 350, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1998160280
 MonoBehaviour:

--- a/Assets/Scenes/Normal.unity
+++ b/Assets/Scenes/Normal.unity
@@ -381,7 +381,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -210, y: 400}
+  m_AnchoredPosition: {x: -190, y: 400}
   m_SizeDelta: {x: 350, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &264319199

--- a/Assets/Scripts/UI/ScoreText.cs
+++ b/Assets/Scripts/UI/ScoreText.cs
@@ -14,14 +14,19 @@ public class ScoreText : MonoBehaviour
 
     public Text scoreText;
 
+    Vector3 defaultScale;
+
     private void Start()
     {
-       SetScore(); 
+        defaultScale = this.transform.localScale;
+        SetScore(); 
     }
     
     public void SetScore()
     {
         scoreText.text = $"ぐれいず : {playerStatus.playerGraze}";
+        transform.DOKill();
+        transform.localScale = defaultScale;
         transform.DOPunchScale(new Vector2(0.1f, 0.1f), 0.02f);
     }
 }


### PR DESCRIPTION
## 概要
<!-- 今回のPRの 実装内容 & 変更するに至った背景 を記載してください。 -->

## デバッグ項目
<!--
実装に不具合がないことを確認するために行った項目です。
- [ ] 入力例 1
- [ ] 入力例 2
-->

## スクリーンショット
<!--
実際にどのような表示かの写真を貼り付ける項目です。
動画の場合は下記の表を消して、[この記事](https://zenn.dev/naminodarie/articles/27f9c260fd81fd)を参考に動画を追加してください。
-->

| Before | After |
| :-: | :-: |
| <img width="450" alt="" src=""> | <img width="450" alt="" src=""> |

## 参考URL
<!--
参考にした記事があれば、そのURLを記載してください。
- 参考にしたURL 1
- 参考にしたURL 2
-->

## Self-Checking points 🚨

レビューを依頼する前に必ず確認してほしいポイントです。
一般的な項目を上げているので、プロジェクト毎に必要なポイントがあれば各リポジトリで追加してください。

### 共通 (命名)
- [ ] `data`, `info`, `value` などの汎用的で抽象度の高い変数名を使っていない → [参考](https://neos21.net/blog/2020/01/28-01.html) 
- [ ] 配列には末尾に `s` をつけて複数形にするか `xxxList` と命名することで配列であることを明確にしている → [参考](https://teratail.com/questions/161176)
- [ ] マジックナンバーは極力存在せず、定数を用いて表現されている → [参考](https://twitter.com/program_shiba/status/1483378634975072260)
- [ ] パッと見で何をやってるかわからないような処理の結果を **説明変数** している → [参考](https://wb-hp.com/blog/2020/11/09/explanatory-variable.html)
- [ ] 複雑な条件式の結果を **要約変数** を適用している → [参考](https://twitter.com/hakuto00/status/1362608154840760320)
- [ ] 関数は動詞始まりにして、何をする関数かを明確にしている → [参考](https://zenn.dev/ccccc/articles/5a60336f54f429)

### 共通 (処理系)
- [ ] **早期リターン（ガード節）** を適用することで条件分岐の簡略化している → [参考](https://zenn.dev/media_engine/articles/early_return)
- [ ] if文では「調査対象」を左側に、「比較対象」を右側に配置している → [参考](https://twitter.com/yuuuma_11/status/1347374986160340992/photo/2)
- [ ] 値のパターンによって分岐する場合は `if/else文` ではなく、`switch文` を使う → [参考](https://blog.senseshare.jp/if-switch.html)

### 共通 (コメント系)
- [ ] コメントには適切なアノテーションコメントが記載されている → [参考](https://qiita.com/taka-kawa/items/673716d77795c937d422)

### C# (命名)
- [ ] ローカル変数 には `キャメルケース` を利用する → [参考](https://qiita.com/TakeshiNishioka/items/501979ad126e9707758c)
- [ ] メソッド, クラス, 定数, Enum, 型変数, 例外, 名前空間, モジュール には `パスカルケース` を利用する → [参考](https://qiita.com/TakeshiNishioka/items/501979ad126e9707758c)

### C# (コメント系)
- [ ] クラス, メソッド には `ドキュメントコメント` を記載している → [参考](https://ekulabo.com/use-doc-comment)

### Unity (処理系)
- [ ] `Find` や `GetComponent` は極力使用せずに、`SerializeField` などを使うようにしている → [参考](https://northprint.net/?p=92)
- [ ] クラス内で完結する変数には `Public変数` ではなく `Private変数` を使っている → [参考](https://qiita.com/makopo/items/8ef280b00f1cc18aec91)
- [ ] アタッチするオブジェクトのクラスが明確な場合は `Prefabのシリアライズ` に `GameObject` を使わず,<br>アタッチするオブジェクトのクラスを明示的に指定している → [参考](https://r-ngtm.hatenablog.com/entry/2018/02/22/200320)
- [ ] ゲームロジックの実装はUpdateではなく、FixedUpdateで行っている → [参考](https://qiita.com/ogawa-to/items/c9988f45516c0d331354)

### 共通 (その他)
- [ ] フォーマット差分などは PR 上に一言 `インラインコメント` を付けて、レビュワーが省エネできるように → [参考](https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request)
